### PR TITLE
Fix MSRV bump

### DIFF
--- a/src/table/row.rs
+++ b/src/table/row.rs
@@ -27,7 +27,7 @@ impl<'a> Row<'a> {
                 .iter()
                 .zip(widths)
                 .map(|(cell, &width)| cell.unicode_pad(width, Alignment::Left, true))
-                .map(|s| format!("{:pad$}{s}{:pad$}", "", "", pad = fmt.padding)),
+                .map(|s| format!("{:pad$}{}{:pad$}", "", s, "", pad = fmt.padding)),
             sep,
         )
         .try_for_each(|s| write!(wtr, "{}", s))?;


### PR DESCRIPTION
## Check list

- [x] I have read through the [README](https://github.com/wfxr/csview/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

The use of format args capture forces the Minimum Supported Rust Version for csview to be Rust 1.58. Maintaining a low MSRV is allows building and packaging csview on systems that have older rust versions. Since the format args capture is used in a single location in the entire code, it seems like the MSRV bump is an untended change.

It might also be a good idea to set the [`rust-version`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) in `Cargo.toml`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CICD related improvement

## Test environment

- OS
    - [x] Linux
        Rust `1.57.0` as packaged by Voidlinux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
