### PR TITLE
Feat: Support alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Year,Make,Model,Description,Price
 
 $ csview example.csv
 ┌──────┬───────┬───────────────────────────────────┬───────────────────────────┬─────────┐
-│ Year │ Make  │ Model                             │ Description               │ Price   │
+│ Year │ Make  │               Model               │        Description        │  Price  │
 ├──────┼───────┼───────────────────────────────────┼───────────────────────────┼─────────┤
 │ 1997 │ Ford  │ E350                              │ ac, abs, moon             │ 3000.00 │
 │ 1999 │ Chevy │ Venture "Extended Edition"        │                           │ 4900.00 │

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,14 @@ pub struct App {
     /// Limit column widths sniffing to the specified number of rows. Specify "0" to cancel limit.
     #[clap(long, default_value_t = 1000, name = "LIMIT")]
     pub sniff: usize,
+
+    /// Specify the alignment of the table header.
+    #[clap(long, default_value_t = Alignment::Center, possible_values = Alignment::VARIANTS, ignore_case = true)]
+    pub header_align: Alignment,
+
+    /// Specify the alignment of the table body.
+    #[clap(long, default_value_t = Alignment::Left, possible_values = Alignment::VARIANTS, ignore_case = true)]
+    pub body_align: Alignment,
 }
 
 #[derive(Display, EnumString, EnumVariantNames)]
@@ -57,4 +65,12 @@ pub enum TableStyle {
     Reinforced,
     Markdown,
     Grid,
+}
+
+#[derive(Display, EnumString, EnumVariantNames)]
+#[strum(ascii_case_insensitive)]
+pub enum Alignment {
+    Left,
+    Center,
+    Right,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,8 @@ fn try_main() -> anyhow::Result<()> {
         padding,
         indent,
         sniff,
+        header_align,
+        body_align,
     } = App::parse();
 
     let stdout = io::stdout();
@@ -79,6 +81,6 @@ fn try_main() -> anyhow::Result<()> {
 
     let sniff = if sniff == 0 { usize::MAX } else { sniff };
     let table = Table::new(rdr, sniff, number)?;
-    table.writeln(wtr, &table_style(style, padding, indent))?;
+    table.writeln(wtr, &table_style(style, padding, indent, header_align, body_align))?;
     Ok(())
 }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -40,7 +40,7 @@ impl Table {
                 true => iter::once("#").chain(header.into_iter()).collect(),
                 false => header.into_iter().collect(),
             };
-            row.writeln(wtr, fmt, widths)?;
+            row.writeln(wtr, fmt, widths, fmt.header_align)?;
             if iter.peek().is_some() {
                 fmt.rowseps
                     .snd
@@ -55,11 +55,11 @@ impl Table {
                 true => {
                     let seq = seq.to_string();
                     let row: Row = iter::once(seq.as_ref()).chain(record.into_iter()).collect();
-                    row.writeln(wtr, fmt, widths)?;
+                    row.writeln(wtr, fmt, widths, fmt.body_align)?;
                 }
                 false => {
                     let row: Row = record.into_iter().collect();
-                    row.writeln(wtr, fmt, widths)?;
+                    row.writeln(wtr, fmt, widths, fmt.body_align)?;
                 }
             };
             if let Some(mid) = &fmt.rowseps.mid {

--- a/src/table/row.rs
+++ b/src/table/row.rs
@@ -18,7 +18,7 @@ impl<'a> FromIterator<&'a str> for Row<'a> {
 }
 
 impl<'a> Row<'a> {
-    pub fn write<T: Write>(&self, wtr: &mut T, fmt: &Style, widths: &[usize]) -> Result<()> {
+    pub fn write<T: Write>(&self, wtr: &mut T, fmt: &Style, widths: &[usize], align: Alignment) -> Result<()> {
         let sep = fmt.colseps.mid.map(|c| c.to_string()).unwrap_or_default();
         write!(wtr, "{:indent$}", "", indent = fmt.indent)?;
         fmt.colseps.lhs.map(|sep| fmt.write_col_sep(wtr, sep)).transpose()?;
@@ -26,7 +26,7 @@ impl<'a> Row<'a> {
             self.cells
                 .iter()
                 .zip(widths)
-                .map(|(cell, &width)| cell.unicode_pad(width, Alignment::Left, true))
+                .map(|(cell, &width)| cell.unicode_pad(width, align, true))
                 .map(|s| format!("{:pad$}{}{:pad$}", "", s, "", pad = fmt.padding)),
             sep,
         )
@@ -35,8 +35,8 @@ impl<'a> Row<'a> {
         Ok(())
     }
 
-    pub fn writeln<T: Write>(&self, wtr: &mut T, fmt: &Style, widths: &[usize]) -> Result<()> {
-        self.write(wtr, fmt, widths).and_then(|_| writeln!(wtr))
+    pub fn writeln<T: Write>(&self, wtr: &mut T, fmt: &Style, widths: &[usize], align: Alignment) -> Result<()> {
+        self.write(wtr, fmt, widths, align).and_then(|_| writeln!(wtr))
     }
 }
 
@@ -53,7 +53,7 @@ mod test {
         let fmt = Style::default();
         let widths = [3, 4];
 
-        row.writeln(buf, &fmt, &widths)?;
+        row.writeln(buf, &fmt, &widths, Alignment::Left)?;
         assert_eq!("| a   | b    |\n", str::from_utf8(buf)?);
         Ok(())
     }
@@ -65,8 +65,32 @@ mod test {
         let fmt = Style::default();
         let widths = [10, 8, 2];
 
-        row.writeln(buf, &fmt, &widths)?;
+        row.writeln(buf, &fmt, &widths, Alignment::Left)?;
         assert_eq!("| 李磊(Jack) | 四川省成 | 💍 |\n", str::from_utf8(buf)?);
+        Ok(())
+    }
+
+    #[test]
+    fn write_align_center() -> Result<()> {
+        let row = Row::from_iter(["a", "b"]);
+        let buf = &mut Vec::new();
+        let fmt = Style::default();
+        let widths = [3, 4];
+
+        row.writeln(buf, &fmt, &widths, Alignment::Center)?;
+        assert_eq!("|  a  |  b   |\n", str::from_utf8(buf)?);
+        Ok(())
+    }
+
+    #[test]
+    fn write_align_right() -> Result<()> {
+        let row = Row::from_iter(["a", "b"]);
+        let buf = &mut Vec::new();
+        let fmt = Style::default();
+        let widths = [3, 4];
+
+        row.writeln(buf, &fmt, &widths, Alignment::Right)?;
+        assert_eq!("|   a |    b |\n", str::from_utf8(buf)?);
         Ok(())
     }
 }

--- a/src/table/style.rs
+++ b/src/table/style.rs
@@ -1,5 +1,7 @@
 use std::io::{Result, Write};
 
+use unicode_truncate::Alignment;
+
 #[derive(Debug, Clone, Copy)]
 pub struct RowSeps {
     /// Top separator row (top border)
@@ -123,15 +125,23 @@ pub struct Style {
 
     /// Global indentation
     pub indent: usize,
+
+    /// Header alignment
+    pub header_align: Alignment,
+
+    /// Data alignment
+    pub body_align: Alignment,
 }
 
 impl Default for Style {
     fn default() -> Self {
         Self {
-            indent:  0,
-            padding: 1,
-            colseps: ColSeps::default(),
-            rowseps: RowSeps::default(),
+            indent:       0,
+            padding:      1,
+            colseps:      ColSeps::default(),
+            rowseps:      RowSeps::default(),
+            header_align: Alignment::Center,
+            body_align:   Alignment::Left,
         }
     }
 }
@@ -215,6 +225,16 @@ impl StyleBuilder {
 
     pub fn indent(mut self, indent: usize) -> Self {
         self.format.indent = indent;
+        self
+    }
+
+    pub fn header_align(mut self, align: Alignment) -> Self {
+        self.format.header_align = align;
+        self
+    }
+
+    pub fn body_align(mut self, align: Alignment) -> Self {
+        self.format.body_align = align;
         self
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,17 @@
+use cli::Alignment;
+
 use crate::{
-    cli::TableStyle,
+    cli::{self, TableStyle},
     table::{RowSep, Style, StyleBuilder},
 };
 
-pub fn table_style(style: TableStyle, padding: usize, indent: usize) -> Style {
+pub fn table_style(
+    style: TableStyle,
+    padding: usize,
+    indent: usize,
+    header_align: Alignment,
+    body_align: Alignment,
+) -> Style {
     let builder = match style {
         TableStyle::None => StyleBuilder::new().clear_seps(),
         TableStyle::Ascii => StyleBuilder::new().col_sep('|').row_seps(
@@ -45,5 +53,20 @@ pub fn table_style(style: TableStyle, padding: usize, indent: usize) -> Style {
             RowSep::new('─', '└', '┴', '┘'),
         ),
     };
-    builder.padding(padding).indent(indent).build()
+    builder
+        .padding(padding)
+        .indent(indent)
+        .header_align(header_align.into())
+        .body_align(body_align.into())
+        .build()
+}
+
+impl From<Alignment> for unicode_truncate::Alignment {
+    fn from(a: Alignment) -> Self {
+        match a {
+            Alignment::Left => unicode_truncate::Alignment::Left,
+            Alignment::Center => unicode_truncate::Alignment::Center,
+            Alignment::Right => unicode_truncate::Alignment::Right,
+        }
+    }
 }


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/csview/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

Add alignment support to both table header and body. The header now center aligned by default:


<img width="1142" alt="image" src="https://user-images.githubusercontent.com/6105425/191935823-e28e6951-cc2f-44c2-9b57-0b14413f9142.png">

Closes #78 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Breaking change
- [ ] Documentation change
- [ ] CICD related improvement

## Test environment

- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
