### PR TITLE
refactor: replace unmaintained `atty`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,17 +57,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,7 +150,6 @@ name = "csview"
 version = "1.2.4"
 dependencies = [
  "anyhow",
- "atty",
  "clap",
  "clap_complete",
  "csv",
@@ -220,15 +208,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "itertools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ anyhow = "1.0"
 unicode-width = "0"
 unicode-truncate = "0"
 itertools = "0.12"
-atty = "0.2"
 [target.'cfg(target_family = "unix")'.dependencies]
 pager = { version = "0.16", optional = true }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use cli::App;
 use csv::{ErrorKind, ReaderBuilder};
 use std::{
     fs::File,
-    io::{self, BufWriter, Read},
+    io::{self, BufWriter, IsTerminal, Read},
     process,
 };
 use table::TablePrinter;
@@ -86,7 +86,7 @@ fn try_main() -> anyhow::Result<()> {
         .has_headers(!no_headers)
         .from_reader(match file {
             Some(path) => Box::new(File::open(path)?) as Box<dyn Read>,
-            None if atty::is(atty::Stream::Stdin) => bail!("no input file specified (use -h for help)"),
+            None if io::stdin().is_terminal() => bail!("no input file specified (use -h for help)"),
             None => Box::new(io::stdin()),
         });
 


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [ ] I have read through the [README](https://github.com/wfxr/csview/blob/master/README.md) (especially F.A.Q section)
- [ ] I have searched through the existing issues or pull requests
- [ ] I have performed a self-review of my code and commented hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (when necessary)

## Description

`atty` is unmaintained and now we can do the same thing using std.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CICD related improvement

## Test environment

- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
